### PR TITLE
Fix split causing part of comment to disappear

### DIFF
--- a/languageServer/documents.go
+++ b/languageServer/documents.go
@@ -121,7 +121,7 @@ func reformatDocument(uri DocumentUri) string {
 		withoutComment := strings.Split(line, "#")[0]
 		withComment := ""
 		if strings.Contains(line, "#") {
-			withComment = "#" + strings.Split(line, "#")[1]
+			withComment = "#" + strings.SplitN(line, "#", 2)[1]
 		}
 		lineWithoutWhitespace := strings.TrimLeft(withoutComment, " \t")
 		lineWithoutWhitespace = strings.ReplaceAll(lineWithoutWhitespace, "\t", " ")


### PR DESCRIPTION
If there are multiple pound symbols within a comment (a common case is commenting out a line of code that had a comment), the formatter will no longer clear any previous comments.

Example of this issue before changes made:
`# addi x10, x7, 0 # Max = z`

With the old formatter, saving would completely remove the comment due to splitting on the pound symbol:

`# addi x10, x7, 0`