### PR TITLE
Lower runtimeLimit and fixed issue w/ Step Out

### DIFF
--- a/emulator/debugger.go
+++ b/emulator/debugger.go
@@ -510,12 +510,16 @@ func handleStepIn(seq int) {
 }
 
 func handleStepOut(seq int) {
-	// get line of last callstack frame
-	liveEmulator.breakAddr = liveEmulator.callStack[len(liveEmulator.callStack)-1] + 4
-	if continueChan != nil {
-		continueChan <- true
+	if (len(liveEmulator.callStack) < 1) {
+		sendOutput("Not currently in a function call; cannot Step Out.", true)
+	} else {
+		// get line of last callstack frame
+		liveEmulator.breakAddr = liveEmulator.callStack[len(liveEmulator.callStack)-1] + 4
+		if continueChan != nil {
+			continueChan <- true
+		}
+		sendResponse("stepOut", seq, true, EmptyResponse{})
 	}
-	sendResponse("stepOut", seq, true, EmptyResponse{})
 }
 
 func handleContinue(seq int) {

--- a/emulator/emulator.go
+++ b/emulator/emulator.go
@@ -82,7 +82,8 @@ func (inst *EmulatorInstance) Emulate(startAddr uint32) {
 	for inst.di < inst.runtimeLimit && !inst.terminated {
 		inst.pc += 4
 		if inst.pc == 0x20352035 || inst.pc == 0x20352034 {
-			// magic number to end the emulator
+			// end the emulator when magic number is reached (0x20352035 is the return address
+			// of the main program)
 			break
 		} else if inst.pc == 0x20352037 {
 			// magic number to resume from an interrupt

--- a/emulator/evaluation.go
+++ b/emulator/evaluation.go
@@ -111,7 +111,7 @@ func evalWorker(memImg memoryImageContext, seedQueue chan uint32, stdOutMutex *s
 			StdOutCallback: func(b byte) {
 				// nothing..
 			},
-			RuntimeLimit: 1000000, // 100,000 instructions, which doesn't include the CPP code
+			RuntimeLimit: 100000, // 100,000 instructions, which doesn't include the CPP code
 		}
 
 		emulator := NewEmulator(config)


### PR DESCRIPTION
Lowered runtimeLimit from 1M to 100K for DI so that infinite loops don't take forever to timeout.

Also, checked  if anything is on callStack before Step Out so that emulator doesn't crash w/ an error.