### PR TITLE
Add runConsole subcommand

### DIFF
--- a/assembler/reflection.go
+++ b/assembler/reflection.go
@@ -34,6 +34,20 @@ func (r *AssembledResult) GetTextLabelForAddress(address uint32) string {
 	return closestLabel
 }
 
+func (r *AssembledResult) GetSourceLineFromAddress(address uint32) string {
+	line, ok := r.AddressToLine[address]
+	if !ok {
+		return "??? Unknown location"
+	}
+	lineContent := r.fileContents[line]
+	commentIndex := strings.Index(lineContent, "#")
+	if commentIndex != -1 {
+		lineContent = lineContent[:commentIndex]
+	}
+	lineContent = strings.TrimSpace(lineContent)
+	return lineContent
+}
+
 func (r *AssembledResult) PrettyPrintInstruction(address uint32) string {
 	// should be in the form of: fileName:lineNumber label
 	if _, ok := r.AddressToLine[address]; !ok {

--- a/emulator/debugger.go
+++ b/emulator/debugger.go
@@ -997,6 +997,7 @@ func sendScreenUpdates() {
 		Status  string                 `json:"status"`
 		Stats   map[string]int         `json:"stats"`
 		Memory  map[string]string      `json:"memory"`
+		Registers [32]uint32           `json:"registers"`
 	}
 
 	// Get current gp memory and stack memory
@@ -1007,6 +1008,7 @@ func sendScreenUpdates() {
 
 	mainMemory := getMemoryBase64(int(gp), false, 2)
 	stackMemory := getMemoryBase64(int(sp), true, 1)
+	registers := liveEmulator.registers
 
 	packet := ScreenUpdate{
 		Width:   liveEmulator.display.width,
@@ -1025,6 +1027,7 @@ func sendScreenUpdates() {
 			"main":  mainMemory,
 			"stack": stackMemory,
 		},
+		Registers: registers,
 	}
 
 	sendEvent("riscv_screen", packet)

--- a/emulator/evaluation.go
+++ b/emulator/evaluation.go
@@ -120,7 +120,7 @@ func RunConsole(elfFilePath, asmFilePath string) {
 	const instructionCount = 1_000_000
 
 	stdout := make(chan byte, bufferSize)
-	stderr := make(chan RuntimeException, 0)
+	stderr := make(chan RuntimeException, bufferSize)
 
 	config := EmulatorConfig{
 		StackStartAddress:       0x7FFFFFF0,
@@ -149,7 +149,6 @@ func RunConsole(elfFilePath, asmFilePath string) {
 		emulator.Emulate(memImg.assemblyEntry)
 		close(stdout)
 	}()
-
 
 	var sb strings.Builder
 	for {

--- a/main.go
+++ b/main.go
@@ -74,6 +74,10 @@ func main() {
 		}
 
 		emulator.BatchRun(elfFilePath, asmFilePath, seedInts, true)
+	} else if len(args) == 3 && args[0] == "runConsole" {
+		asmFilePath := args[1]
+		elfFilePath := args[2]
+		emulator.RunConsole(elfFilePath, asmFilePath)
 	} else {
 		log.Fatalln("Invalid arguments:", os.Args)
 	}


### PR DESCRIPTION
This command executes a single assembly language program, then emits a JSON structure containng the program stdout, final register state, and state of the first 1024 words of its data segment.

This subcommand is suitable for interactive use from a console, without the use a web browser (so it differs from runELF) but also provides detailed output of the final state of the emulator (so it differs from runBatch).